### PR TITLE
Fix for incorrect marking EOL if connection fails

### DIFF
--- a/apt_mirror_updater/__init__.py
+++ b/apt_mirror_updater/__init__.py
@@ -19,6 +19,7 @@ import logging
 import os
 import sys
 import time
+import urllib2
 
 # External dependencies.
 from capturer import CaptureOutput

--- a/apt_mirror_updater/__init__.py
+++ b/apt_mirror_updater/__init__.py
@@ -263,7 +263,8 @@ class AptMirrorUpdater(PropertyManager):
         logger.debug("Checking whether %s suite %s is EOL ..",
                      self.distributor_id.capitalize(),
                      self.distribution_codename.capitalize())
-        release_is_eol = not self.validate_mirror(self.security_url)
+        # only set EOL if we can connect but validation fails - this prevents incorrect setting of EOL if network connection fails
+        release_is_eol = self.can_connect_to_mirror(self.security_url) and not self.validate_mirror(self.security_url)
         logger.debug("The %s suite %s is %s.",
                      self.distributor_id.capitalize(),
                      self.distribution_codename.capitalize(),
@@ -597,6 +598,30 @@ class AptMirrorUpdater(PropertyManager):
                             else:
                                 backoff_time += backoff_time / 3
         raise Exception("Failed to update package lists %i consecutive times?!" % max_attempts)
+
+    def can_connect_to_mirror(self, mirror_url):
+        """
+        Make sure the mirror can be connected to
+
+        :param mirror_url: The base URL of the mirror (a string).
+        :returns: :data:`True` if the mirror can be connected to,
+                  :data:`False` otherwise.
+.
+        """
+        mirror_url = normalize_mirror_url(mirror_url)
+        logger.info("Checking whether %s can be connected to.", mirror_url)
+        mirror = CandidateMirror(mirror_url=mirror_url, updater=self)
+        try:
+            response = fetch_url(mirror.release_gpg_url, retry=False)
+            mirror.release_gpg_contents = response.read()
+        except urllib2.URLError as e:
+            if 'connection refused' in str(e.reason).lower():
+                logger.warning("Cannot connect to %s.", mirror_url)
+                return False
+        except Exception:
+            pass
+        logger.info("Can connect to %s.", mirror_url)
+        return True
 
     def validate_mirror(self, mirror_url):
         """


### PR DESCRIPTION
This fixes the bug that incorrectly assumes EOL if connection fails.
See https://github.com/xolox/python-apt-mirror-updater/issues/1