### PR TITLE
Add optional additional args to apt-get update

### DIFF
--- a/apt_mirror_updater/__init__.py
+++ b/apt_mirror_updater/__init__.py
@@ -437,8 +437,8 @@ class AptMirrorUpdater(PropertyManager):
         timer = Timer()
         logger.info("Updating package lists of %s ..", self.context)
         if args:
-	         argarr = ['update'] + args
-	         self.context.execute('apt-get', *argarr, sudo=True)
+            argarr = ['update'] + args
+            self.context.execute('apt-get', *argarr, sudo=True)
         else:
             self.context.execute('apt-get', 'update', sudo=True)
         logger.info("Finished updating package lists of %s in %s ..", self.context, timer)

--- a/apt_mirror_updater/__init__.py
+++ b/apt_mirror_updater/__init__.py
@@ -432,11 +432,15 @@ class AptMirrorUpdater(PropertyManager):
             self.smart_update()
         return self.context
 
-    def dumb_update(self):
+    def dumb_update(self, args=None):
         """Update the system's package lists (by running ``apt-get update``)."""
         timer = Timer()
         logger.info("Updating package lists of %s ..", self.context)
-        self.context.execute('apt-get', 'update', sudo=True)
+        if args:
+	         argarr = ['update'] + args
+	         self.context.execute('apt-get', *argarr, sudo=True)
+        else:
+            self.context.execute('apt-get', 'update', sudo=True)
         logger.info("Finished updating package lists of %s in %s ..", self.context, timer)
 
     def generate_sources_list(self, **options):


### PR DESCRIPTION
Added the ability to pass additional arguments to apt-get update in dumb_update.
See: https://github.com/xolox/python-apt-mirror-updater/issues/3